### PR TITLE
Stylesheet

### DIFF
--- a/wp_dso_publish/setup.py
+++ b/wp_dso_publish/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='wp_dso_publish',
-    version='0.26',
+    version='0.27',
     packages=[
         'wp_dso_publish'
     ],

--- a/wp_dso_publish/setup.py
+++ b/wp_dso_publish/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='wp_dso_publish',
-    version='0.25',
+    version='0.26',
     packages=[
         'wp_dso_publish'
     ],

--- a/wp_dso_publish/wp_dso_publish/style.css
+++ b/wp_dso_publish/wp_dso_publish/style.css
@@ -1,7 +1,7 @@
 QMainWindow{
     background-color: gray;
-	height: 1000px;
-	width: 1000px;
+    height: 1000px;
+    width: 1000px;
 }
 
 QLabel{
@@ -14,11 +14,13 @@ QLineEdit{
     border: 1px solid #CCC;
     height: 30px;
     padding-left: 10px;
+    background: black;
+    color: white;
 }
 
 QPushButton{
     background: #3498db;
-    color: #ffffff;
+    color: white;
     padding: 10px 20px 10px 20px;
     border-radius: 6px;
     max-width: 200px;
@@ -29,12 +31,13 @@ QPushButton:hover {
 }
 
 QPlainTextEdit {
-	max-width: 650px;
-	min-width: 650px;
-	max-height: 350px;
-	min-height: 350px;
-	border: 1px solid #CCC;
+    max-width: 650px;
+    min-width: 650px;
+    max-height: 350px;
+    min-height: 350px;
+    border: 1px solid #CCC;
     background: black;
+    color: white;
 }
 
 /*Use the # and the name of the variable to access to a specific the Control*/


### PR DESCRIPTION
Update based on Laura's complaint

"Could you fix this? The output window is all black. You have to highlight the text in order to see it. Can this be fixed before Wednesday?"

<img width="764" alt="Screen Shot 2019-08-09 at 3 27 50 PM" src="https://user-images.githubusercontent.com/12304033/62892124-75cf6600-bd15-11e9-9fc7-25f0c984613d.png">


The fix is to explicitly define font color to be white, otherwise probably the default is inherited. 